### PR TITLE
Hide tick stats behind debug toggle

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -16,6 +16,11 @@ export function initEvents() {
   el('#btnClaimOffline').addEventListener('click', () => { const ms = applyOfflineProgress(); renderAll(); showToast(`Applied ${Math.floor(ms / 60000)} min of offline.`); });
   el('#btnRunTests').addEventListener('click', () => runTests());
   el('#optAutosave').addEventListener('change', e => { data.meta.autosave = e.target.checked; });
-  el('#optDebug').addEventListener('change', e => { data.meta.debug = e.target.checked; });
+  el('#optDebug').addEventListener('change', e => {
+    const dbg = e.target.checked;
+    data.meta.debug = dbg;
+    el('#tickInfo').hidden = !dbg;
+    if (!dbg) el('#tickInfo').textContent = '';
+  });
   el('#optOfflineHours').addEventListener('change', e => { data.meta.offlineCapHrs = clamp(parseInt(e.target.value || '8'), 0, 24); e.target.value = data.meta.offlineCapHrs; });
 }

--- a/js/persistence.js
+++ b/js/persistence.js
@@ -28,6 +28,7 @@ export function load() {
   }
   el('#optAutosave').checked = !!data.meta.autosave;
   el('#optDebug').checked = !!data.meta.debug;
+  el('#tickInfo').hidden = !data.meta.debug;
   el('#optOfflineHours').value = data.meta.offlineCapHrs;
 }
 

--- a/modules/aside.html
+++ b/modules/aside.html
@@ -1,6 +1,6 @@
 <aside>
   <div class="panel" style="margin:10px">
-    <div class="phead"><b>Stats</b><small class="muted" id="tickInfo">t=0</small></div>
+    <div class="phead"><b>Stats</b><small class="muted" id="tickInfo" hidden></small></div>
     <div class="list" id="statList"></div>
   </div>
   <div class="panel" style="margin:10px">

--- a/modules/main.html
+++ b/modules/main.html
@@ -49,7 +49,7 @@
       <div class="phead"><b>Settings</b><small class="muted">QoL, data & tests</small></div>
       <div class="list">
         <label class="item"><span>Autosave every 30s</span><input type="checkbox" id="optAutosave"></label>
-        <label class="item"><span>Show tick debug</span><input type="checkbox" id="optDebug"></label>
+        <label class="item"><span>Enable debug</span><input type="checkbox" id="optDebug"></label>
         <div class="item"><span>Offline progress cap</span><span><input type="number" id="optOfflineHours" min="0" max="24" step="1" style="width:70px"> h</span></div>
       </div>
       <div class="footer">


### PR DESCRIPTION
## Summary
- Rename debug setting to "Enable debug"
- Show tick stats only when debug mode is enabled

## Testing
- `node -e "console.log('no tests to run')"`


------
https://chatgpt.com/codex/tasks/task_e_689bc195abf8832a9f067d08207a12a6