### PR TITLE
Hide unowned items in inventory

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -69,7 +69,9 @@ export function renderOverview() {
   const g = el('#overviewGrid'); g.innerHTML = '';
   const cards = [
     ['Gold', `Earned from many actions.`, `<div class="kv"><b>${fmt(data.gold)}</b><small class="muted">coins</small></div>`],
-    ['Inventory', `Your current stock.`, Object.entries(data.inventory).map(([k, v]) => `<span class="chip">${k}: ${fmt(v)}</span>`).join(' ')],
+    ['Inventory', `Your current stock.`, Object.entries(data.inventory)
+      .filter(([_, v]) => v > 0)
+      .map(([k, v]) => `<span class="chip">${k}: ${fmt(v)}</span>`).join(' ')],
     ['Training', `Current skill & task.`, `<div>${data.activeSkill} → <b>${(data.skills[data.activeSkill].task || 'Choose a node')}</b></div>`],
     ['Global Multipliers', `From upgrades.`, `<div class="list">
       <div class="item"><span>Gain</span><b>x${mul.globalGain().toFixed(2)}</b></div>
@@ -83,6 +85,7 @@ export function renderOverview() {
 export function renderInventory() {
   const g = el('#invGrid'); g.innerHTML = '';
   for (const [k, v] of Object.entries(data.inventory)) {
+    if (v <= 0) continue;
     const card = document.createElement('div'); card.className = 'panel';
     const name = itemMap[k] || k;
     card.innerHTML = `<div class="phead"><b>${name}</b><small class="muted">Resource</small></div><div class="kv"><b>${fmt(v)}</b></div>`;


### PR DESCRIPTION
## Summary
- Only show items with quantity >0 in inventory panel and overview card

## Testing
- `node --experimental-vm-modules -e "import('./js/tests.js').then(m=>m.runTests()).catch(e=>console.error(e))"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689bc15627f8832aa9493eafe3c80983