### PR TITLE
Fix skill progress bar to reflect level progress

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -7,7 +7,7 @@ import enemies from './enemies.js';
 import {mul, canAfford, applyUpgradeEffects} from './helpers.js';
 import {queueCraft} from './crafting.js';
 import {getEnemy} from './combat.js';
-import {el, fmt} from './utils.js';
+import {el, fmt, xpForLevel} from './utils.js';
 
 export function tabButton(id, label) {
   const b = document.createElement('button'); b.className = 'tab'; b.role = 'tab'; b.textContent = label; b.dataset.tab = id; b.addEventListener('click', () => activateTab(id, b)); return b;
@@ -39,7 +39,10 @@ export function renderSkills() {
     const sk = data.skills[name];
     const row = document.createElement('div'); row.className = 'item';
     const active = data.activeSkill === name;
-    row.innerHTML = `<div><b>${name}</b><div class="bar"><span style="width:${(sk.xp % 100) / 1}%"></span></div><small class="muted">Lv ${sk.lvl} · ${fmt(sk.xp)} XP</small></div>
+    const cur = xpForLevel(sk.lvl);
+    const next = xpForLevel(sk.lvl + 1);
+    const pct = ((sk.xp - cur) / (next - cur)) * 100;
+    row.innerHTML = `<div><b>${name}</b><div class="bar"><span style="width:${pct}%"></span></div><small class="muted">Lv ${sk.lvl} · ${fmt(sk.xp)} XP</small></div>
     <div class="row"><button class="btn ${active ? 'good' : ''}">${active ? 'Training' : 'Train'}</button></div>`;
     row.querySelector('button').addEventListener('click', () => { data.activeSkill = name; renderSkills(); renderTaskPanel(); });
     s.appendChild(row);

--- a/js/utils.js
+++ b/js/utils.js
@@ -8,3 +8,13 @@ export function levelFromXP(xp) {
   while (xp >= need) { xp -= need; lvl++; need = Math.floor(need * 1.25 + 10); if (lvl >= 99) break; }
   return lvl;
 }
+
+export function xpForLevel(lvl) {
+  let xp = 0, need = 20;
+  for (let i = 1; i < lvl; i++) {
+    xp += need;
+    need = Math.floor(need * 1.25 + 10);
+    if (i >= 99) break;
+  }
+  return xp;
+}


### PR DESCRIPTION
## Summary
- compute XP thresholds with new `xpForLevel` helper
- render skill progress bar based on current level's XP range

## Testing
- `node -e "global.document={querySelector:()=>null}; import('./js/tests.js').then(m=>m.runTests())"`


------
https://chatgpt.com/codex/tasks/task_e_689bc1b533d4832aad1804670998f4bf