### PR TITLE
Add skill filter to upgrade menu

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -109,8 +109,22 @@ export function renderCrafting() {
 }
 
 export function renderUpgrades() {
+  const sel = el('#upgFilter');
+  if (sel && !sel.dataset.init) {
+    sel.innerHTML = '<option value="all">All</option>';
+    const types = Array.from(new Set(upgrades.map(u => u.type)));
+    types.forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      opt.textContent = t.charAt(0).toUpperCase() + t.slice(1);
+      sel.appendChild(opt);
+    });
+    sel.addEventListener('change', renderUpgrades);
+    sel.dataset.init = '1';
+  }
+  const filter = sel ? sel.value : 'all';
   const g = el('#upgGrid'); g.innerHTML = '';
-  upgrades.forEach(u => {
+  upgrades.filter(u => filter === 'all' || u.type === filter).forEach(u => {
     const lvl = data.upgrades[u.key] || 0; const maxed = lvl >= u.max;
     const cost = Math.floor(u.cost * Math.pow(1.75, lvl));
     const can = canAfford(cost) && !maxed;

--- a/modules/main.html
+++ b/modules/main.html
@@ -19,6 +19,12 @@
 
     <section class="panel" id="tab-upgrades" role="tabpanel" hidden>
       <div class="phead"><b>Upgrades</b><small class="muted">Permanent boosts</small></div>
+      <div class="row">
+        <span class="muted">Filter</span>
+        <select id="upgFilter">
+          <option value="all">All</option>
+        </select>
+      </div>
       <div class="grid" id="upgGrid"></div>
     </section>
 


### PR DESCRIPTION
## Summary
- Add filter dropdown to upgrades panel
- Implement filtering logic to show upgrades by selected skill

## Testing
- `node --experimental-modules -e "import('./js/tests.js').then(m=>m.runTests())"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689bc1f31c68832abd06b918bf84fa8a