### PR TITLE
feat: add search to crafting menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,6 +24,7 @@ main{overflow:auto}
 .btn.good{background:#122b22;border-color:#1b6a56}
 .btn.bad{background:#2b1215;border-color:#6a1b23}
 .btn.warn{background:#2b2412;border-color:#6a5b1b}
+input[type="search"]{padding:.5rem .7rem;border:1px solid #2a2e49;background:#13172c;color:var(--text);border-radius:9px}
 small.muted{color:var(--muted)}
 .row{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
 .kv{display:flex;align-items:baseline;gap:6px}

--- a/js/events.js
+++ b/js/events.js
@@ -2,7 +2,7 @@ import {data} from './data.js';
 import {startStopFight} from './combat.js';
 import {save, exportSave, importSave, hardReset} from './persistence.js';
 import {applyOfflineProgress} from './offline.js';
-import {renderAll} from './render.js';
+import {renderAll, renderCrafting} from './render.js';
 import {runTests} from './tests.js';
 import {el, clamp} from './utils.js';
 import {showToast} from './toast.js';
@@ -18,4 +18,5 @@ export function initEvents() {
   el('#optAutosave').addEventListener('change', e => { data.meta.autosave = e.target.checked; });
   el('#optDebug').addEventListener('change', e => { data.meta.debug = e.target.checked; });
   el('#optOfflineHours').addEventListener('change', e => { data.meta.offlineCapHrs = clamp(parseInt(e.target.value || '8'), 0, 24); e.target.value = data.meta.offlineCapHrs; });
+  el('#craftSearch').addEventListener('input', () => renderCrafting());
 }

--- a/js/render.js
+++ b/js/render.js
@@ -92,7 +92,16 @@ export function renderInventory() {
 
 export function renderCrafting() {
   const g = el('#craftGrid'); g.innerHTML = '';
-  const list = [...nodes.Smithing, ...nodes.Cooking];
+  const q = (el('#craftSearch')?.value || '').trim().toLowerCase();
+  const list = [...nodes.Smithing, ...nodes.Cooking].filter(n => {
+    if (!q) return true;
+    const names = [
+      ...Object.keys(n.consume || {}),
+      ...Object.keys(n.yield),
+      n.name
+    ].map(k => (itemMap[k] || k).toLowerCase());
+    return names.some(x => x.includes(q));
+  });
   list.forEach(n => {
     const card = document.createElement('div'); card.className = 'panel';
     const canAff = n.consume ? Object.entries(n.consume).every(([k, v]) => (data.inventory[k] || 0) >= v) : true;

--- a/modules/main.html
+++ b/modules/main.html
@@ -14,6 +14,9 @@
 
     <section class="panel" id="tab-crafting" role="tabpanel" hidden>
       <div class="phead"><b>Crafting</b><small class="muted">Turn resources into useful goods</small></div>
+      <div class="row" style="margin-bottom:8px">
+        <input type="search" id="craftSearch" placeholder="Search by item" style="flex:1">
+      </div>
       <div class="grid" id="craftGrid"></div>
     </section>
 


### PR DESCRIPTION
## Summary
- add search input to crafting panel
- filter crafting options by items used or produced
- wire search box to live re-render and style the input

## Testing
- `node --check js/render.js js/events.js js/crafting.js`
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bc223ac2c832ab849abca18f48692