### PR TITLE
Add Endurance skill for HP scaling

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -5,9 +5,10 @@ import Fishing from './skills/Fishing/index.js';
 import Smithing from './skills/Smithing/index.js';
 import Cooking from './skills/Cooking/index.js';
 import Combat from './skills/Combat/index.js';
+import Endurance from './skills/Endurance/index.js';
 import {VERSION} from './constants.js';
 
-export const skillModules = { Woodcutting, Mining, Fishing, Smithing, Cooking, Combat };
+export const skillModules = { Woodcutting, Mining, Fishing, Smithing, Cooking, Combat, Endurance };
 export const skills = Object.keys(skillModules);
 export const nodes = Object.fromEntries(skills.map(k => [k, skillModules[k].nodes]));
 export const inventory = Object.fromEntries(items.map(i => [i.key, 0]));
@@ -28,6 +29,6 @@ export const data = {
   upgrades: {},
   craftingQueue: [],
   activeSkill: 'Woodcutting',
-  combat: { running: false, area: 'Glade', player: { hpMax: 50, hp: 50, atk: 4, def: 2, spd: 1.0, crit: 0.05 }, enemyKey: 'Slime', progress: 0 },
+  combat: { running: false, area: 'Glade', player: { hpMax: 10, hp: 10, atk: 4, def: 2, spd: 1.0, crit: 0.05 }, enemyKey: 'Slime', progress: 0 },
   ach: {},
 };

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -12,7 +12,10 @@ export function canAfford(cost) {
 
 export function applyUpgradeEffects() {
   const p = data.combat.player;
-  p.hpMax = 50; p.atk = 4; p.def = 2; p.spd = 1.0;
+  const ratio = p.hp / p.hpMax || 1;
+  p.hpMax = 10; p.atk = 4; p.def = 2; p.spd = 1.0;
+  const lvl = data.skills.Endurance ? data.skills.Endurance.lvl : 1;
+  p.hpMax = Math.floor(p.hpMax * Math.pow(1.02, lvl - 1));
   let hpFlat = 0;
   for (const k in data.upgrades) {
     const u = upgrades.find(v => v.key === k); if (!u) continue;
@@ -20,7 +23,7 @@ export function applyUpgradeEffects() {
     if (u.type === 'combatFlat') { if (u.eff.atk) p.atk += u.eff.atk * lvl; if (u.eff.def) p.def += u.eff.def * lvl; if (u.eff.hp) hpFlat += u.eff.hp * lvl; }
     if (u.type === 'combatMul') { if (u.eff.spd) p.spd *= Math.pow(u.eff.spd, lvl); }
   }
-  p.hpMax += hpFlat; p.hp = clamp(p.hp, 1, p.hpMax);
+  p.hpMax += hpFlat; p.hp = clamp(Math.round(p.hpMax * ratio), 1, p.hpMax);
 }
 
 function productOf(pred) {

--- a/js/progress.js
+++ b/js/progress.js
@@ -1,5 +1,5 @@
 import {data} from './data.js';
-import {mul, addInventory} from './helpers.js';
+import {mul, addInventory, applyUpgradeEffects} from './helpers.js';
 import {randInt, levelFromXP} from './utils.js';
 import {showToast} from './toast.js';
 
@@ -8,7 +8,11 @@ export function addSkillXP(skill, amount) {
   const gain = Math.floor(amount * mul.globalXP());
   sk.xp += gain; data.xp += gain;
   const lvlNow = levelFromXP(sk.xp);
-  if (lvlNow > sk.lvl) { sk.lvl = lvlNow; showToast(`${skill} → Lv.${lvlNow}!`); }
+  if (lvlNow > sk.lvl) {
+    sk.lvl = lvlNow;
+    showToast(`${skill} → Lv.${lvlNow}!`);
+    if (skill === 'Endurance') applyUpgradeEffects();
+  }
 }
 
 export const helpers = {addInventory, addSkillXP, randInt, mul};

--- a/js/skills/Endurance/index.js
+++ b/js/skills/Endurance/index.js
@@ -1,0 +1,15 @@
+const skill = 'Endurance';
+
+export const nodes = [
+  {key:'train', name:'Jogging', time:3000, yield:{xp:[5,8]}, xp:0, req:1},
+];
+
+export function perform(state, node, {addSkillXP, randInt}) {
+  for (const [k,[a,b]] of Object.entries(node.yield||{})) {
+    if (k === 'xp') addSkillXP(skill, randInt(a,b));
+  }
+  addSkillXP(skill, node.xp);
+  return true;
+}
+
+export default {nodes, perform};


### PR DESCRIPTION
## Summary
- Introduce new Endurance skill with training node
- Recalculate player HP from base 10 and +2% per Endurance level
- Refresh combat stats when Endurance levels up

## Testing
- `node -e "import('./js/tests.js').then(m=>m.runTests())"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689bc4b2d958832a82594bc4010de1d2