### PR TITLE
Initialize missing skills on save load

### DIFF
--- a/js/persistence.js
+++ b/js/persistence.js
@@ -1,4 +1,4 @@
-import {data} from './data.js';
+import {data, skills} from './data.js';
 import {stats} from './stats.js';
 import {SAVE_KEY} from './constants.js';
 import {showToast} from './toast.js';
@@ -26,6 +26,9 @@ export function load() {
       applyUpgradeEffects();
     } catch (e) { console.warn('Load failed', e); }
   }
+  skills.forEach(s => {
+    if (!data.skills[s]) data.skills[s] = { lvl: 1, xp: 0, task: null };
+  });
   el('#optAutosave').checked = !!data.meta.autosave;
   el('#optDebug').checked = !!data.meta.debug;
   el('#tickInfo').hidden = !data.meta.debug;


### PR DESCRIPTION
## Summary
- Ensure all skills are initialized when loading saved data

## Testing
- `node --input-type=module <<'NODE'
import {data, skills} from './js/data.js';
// simulate loading save without Endurance skill
delete data.skills.Endurance;
console.log('Before fix:', 'Endurance' in data.skills);
// patched load ensures missing skills are initialized
skills.forEach(s => {
  if (!data.skills[s]) data.skills[s] = { lvl: 1, xp: 0, task: null };
});
console.log('After fix:', data.skills.Endurance);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_689bc654c624832abd33f4b0c19a4a51