### PR TITLE
Add Farming skill with crop items

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ IdleGame is an ever-expanding idle universe where each activity is its own fully
 Every branch begins as an independent idle game, but as you progress, their outputs weave together into a unified economy — one where every skill, every system, and every choice feeds into your ultimate empire.
 
 ## Features
-- **Six core skills**: Woodcutting, Mining, Fishing, Smithing, Cooking and Combat.
+- **Eight core skills**: Woodcutting, Mining, Fishing, Smithing, Cooking, Combat, Endurance and Farming.
 - **Inventory & crafting**: Collect wood, ore, fish and more to craft bars, meals and other goods.
 - **Upgrades**: Improve speed, yields and add automation with numerous global and skill-specific upgrades.
 - **Auto-combat**: Fight in a small 2D arena and earn experience and loot even while offline.

--- a/js/data.js
+++ b/js/data.js
@@ -6,9 +6,10 @@ import Smithing from './skills/Smithing/index.js';
 import Cooking from './skills/Cooking/index.js';
 import Combat from './skills/Combat/index.js';
 import Endurance from './skills/Endurance/index.js';
+import Farming from './skills/Farming/index.js';
 import {VERSION} from './constants.js';
 
-export const skillModules = { Woodcutting, Mining, Fishing, Smithing, Cooking, Combat, Endurance };
+export const skillModules = { Woodcutting, Mining, Fishing, Smithing, Cooking, Combat, Endurance, Farming };
 export const skills = Object.keys(skillModules);
 export const nodes = Object.fromEntries(skills.map(k => [k, skillModules[k].nodes]));
 export const inventory = Object.fromEntries(items.map(i => [i.key, 0]));
@@ -17,6 +18,7 @@ export const itemMap = Object.fromEntries(items.map(i => [i.key, i.name]));
 function baseSkills() {
   const obj = {};
   skills.forEach(s => { obj[s] = { lvl: 1, xp: 0, task: null }; });
+  if (obj.Farming) obj.Farming.fields = 4;
   return obj;
 }
 

--- a/js/items.js
+++ b/js/items.js
@@ -14,5 +14,11 @@ export default [
   {key:'bar', name:'Metal Bar'},
   {key:'meal', name:'Meal'},
   {key:'gem', name:'Gem'},
-  {key:'skin', name:'Hide'}
+  {key:'skin', name:'Hide'},
+  {key:'wheat', name:'Wheat'},
+  {key:'barley', name:'Barley'},
+  {key:'oat', name:'Oat'},
+  {key:'apple', name:'Apple'},
+  {key:'tomato', name:'Tomato'},
+  {key:'carrot', name:'Carrot'}
 ];

--- a/js/skills/Farming/index.js
+++ b/js/skills/Farming/index.js
@@ -1,0 +1,25 @@
+import items from '../../items.js';
+
+const skill = 'Farming';
+const map = Object.fromEntries(items.map(i => [i.key, i]));
+const { wheat, barley, oat, apple, tomato, carrot } = map;
+
+export const nodes = [
+  {key: wheat.key, name: 'Wheat', time: 3000, yield: {[wheat.key]: [3, 5]}, xp: 5, req: 1},
+  {key: barley.key, name: 'Barley', time: 4000, yield: {[barley.key]: [3, 5]}, xp: 9, req: 10},
+  {key: oat.key, name: 'Oat', time: 5000, yield: {[oat.key]: [3, 5]}, xp: 13, req: 20},
+  {key: apple.key, name: 'Apples', time: 6000, yield: {[apple.key]: [2, 4]}, xp: 18, req: 30},
+  {key: tomato.key, name: 'Tomatoes', time: 7000, yield: {[tomato.key]: [2, 4]}, xp: 24, req: 40},
+  {key: carrot.key, name: 'Carrots', time: 8000, yield: {[carrot.key]: [2, 3]}, xp: 30, req: 50},
+];
+
+export function perform(state, node, {addInventory, addSkillXP, randInt}) {
+  const fields = state.skills?.Farming?.fields || 1;
+  for (let i = 0; i < fields; i++) {
+    for (const [k, [a, b]] of Object.entries(node.yield || {})) addInventory(k, randInt(a, b));
+  }
+  addSkillXP(skill, node.xp);
+  return true;
+}
+
+export default {nodes, perform};


### PR DESCRIPTION
## Summary
- introduce Farming skill with default 4 fields
- add crop items and nodes for wheat, barley, oats, apples, tomatoes and carrots
- document new skill in features list

## Testing
- `node --check js/skills/Farming/index.js`
- `node --check js/data.js`
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689cd6f10bf4832a817e02ae1c45e973