### PR TITLE
feat: add variable farming grow times

### DIFF
--- a/js/skills/Farming/index.js
+++ b/js/skills/Farming/index.js
@@ -5,12 +5,12 @@ const map = Object.fromEntries(items.map(i => [i.key, i]));
 const { wheat, barley, oat, apple, tomato, carrot } = map;
 
 export const nodes = [
-  {key: wheat.key, name: 'Wheat', time: 3000, yield: {[wheat.key]: [3, 5]}, xp: 5, req: 1},
-  {key: barley.key, name: 'Barley', time: 4000, yield: {[barley.key]: [3, 5]}, xp: 9, req: 10},
-  {key: oat.key, name: 'Oat', time: 5000, yield: {[oat.key]: [3, 5]}, xp: 13, req: 20},
-  {key: apple.key, name: 'Apples', time: 6000, yield: {[apple.key]: [2, 4]}, xp: 18, req: 30},
-  {key: tomato.key, name: 'Tomatoes', time: 7000, yield: {[tomato.key]: [2, 4]}, xp: 24, req: 40},
-  {key: carrot.key, name: 'Carrots', time: 8000, yield: {[carrot.key]: [2, 3]}, xp: 30, req: 50},
+  {key: wheat.key, name: 'Wheat', time: [180000, 240000], yield: {[wheat.key]: [3, 5]}, xp: 5, req: 1},
+  {key: barley.key, name: 'Barley', time: [240000, 300000], yield: {[barley.key]: [3, 5]}, xp: 9, req: 10},
+  {key: oat.key, name: 'Oat', time: [300000, 360000], yield: {[oat.key]: [3, 5]}, xp: 13, req: 20},
+  {key: apple.key, name: 'Apples', time: [360000, 420000], yield: {[apple.key]: [2, 4]}, xp: 18, req: 30},
+  {key: tomato.key, name: 'Tomatoes', time: [420000, 480000], yield: {[tomato.key]: [2, 4]}, xp: 24, req: 40},
+  {key: carrot.key, name: 'Carrots', time: [480000, 540000], yield: {[carrot.key]: [2, 3]}, xp: 30, req: 50},
 ];
 
 export function perform(state, node, {addInventory, addSkillXP, randInt}) {


### PR DESCRIPTION
## Summary
- slow farming nodes to take minutes and randomize grow time
- randomize and store farming duration per cycle in game loop
- show time ranges in UI and reset progress when switching tasks

## Testing
- `node --check js/skills/Farming/index.js js/loop.js js/render.js`


------
https://chatgpt.com/codex/tasks/task_e_689cdb525bfc832a97888bf1f4e63264