### PR TITLE
Move task list to main content area

### DIFF
--- a/modules/aside.html
+++ b/modules/aside.html
@@ -7,8 +7,4 @@
     <div class="phead"><b>Skills</b><small class="muted">Train one at a time</small></div>
     <div class="list" id="skillList"></div>
   </div>
-  <div class="panel" style="margin:10px">
-    <div class="phead"><b>Active Task</b><small id="taskETA" class="muted">—</small></div>
-    <div class="list" id="taskPanel"></div>
-  </div>
 </aside>

--- a/modules/main.html
+++ b/modules/main.html
@@ -2,6 +2,11 @@
   <div style="padding:10px;display:grid;gap:12px">
     <div class="row tabs" role="tablist" id="tabs"></div>
 
+    <section class="panel">
+      <div class="phead"><b>Active Task</b><small id="taskETA" class="muted">—</small></div>
+      <div class="list" id="taskPanel"></div>
+    </section>
+
     <section class="panel" id="tab-overview" role="tabpanel">
       <div class="phead"><b>Overview</b><small class="muted">A compact look at your empire</small></div>
       <div class="grid" id="overviewGrid"></div>


### PR DESCRIPTION
## Summary
- Show task list in the main content window so long task lists have more space
- Remove task panel from sidebar, leaving only stats and skills there

## Testing
- `npm install --no-save jsdom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `node --experimental-default-type=module -e "import('./js/tests.js').then(m => m.runTests());"` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb6e0548832ab843984f06f001af