### PR TITLE
Consolidate crafting into smithing tiles

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -2,7 +2,7 @@ import {data} from './data.js';
 import {startStopFight} from './combat.js';
 import {save, exportSave, importSave, hardReset} from './persistence.js';
 import {applyOfflineProgress} from './offline.js';
-import {renderAll, renderStats, renderCrafting, renderSkills} from './render.js';
+import {renderAll, renderStats, renderSkills} from './render.js';
 import {runTests} from './tests.js';
 import {el, clamp} from './utils.js';
 import {showToast} from './toast.js';
@@ -25,5 +25,4 @@ export function initEvents() {
   });
   el('#optVirtualLevels').addEventListener('change', e => { data.meta.virtualLevels = e.target.checked; renderSkills(); });
   el('#optOfflineHours').addEventListener('change', e => { data.meta.offlineCapHrs = clamp(parseInt(e.target.value || '8'), 0, 24); e.target.value = data.meta.offlineCapHrs; });
-  el('#craftSearch').addEventListener('input', () => renderCrafting());
 }

--- a/modules/main.html
+++ b/modules/main.html
@@ -4,7 +4,7 @@
 
     <section class="panel">
       <div class="phead"><b>Active Task</b><small id="taskETA" class="muted">—</small></div>
-      <div class="list" id="taskPanel"></div>
+      <div id="taskPanel"></div>
     </section>
 
     <section class="panel" id="tab-overview" role="tabpanel">
@@ -15,14 +15,6 @@
     <section class="panel" id="tab-inventory" role="tabpanel" hidden>
       <div class="phead"><b>Inventory</b><small class="muted">Raw resources & materials</small></div>
       <div class="grid" id="invGrid"></div>
-    </section>
-
-    <section class="panel" id="tab-crafting" role="tabpanel" hidden>
-      <div class="phead"><b>Crafting</b><small class="muted">Turn resources into useful goods</small></div>
-      <div class="row" style="margin-bottom:8px">
-        <input type="search" id="craftSearch" placeholder="Search by item" style="flex:1">
-      </div>
-      <div class="grid" id="craftGrid"></div>
     </section>
 
     <section class="panel" id="tab-upgrades" role="tabpanel" hidden>


### PR DESCRIPTION
## Summary
- remove Crafting tab and move its functionality into Smithing
- show smithing costs, times and yields in sortable tile grid
- drop unused crafting search event

## Testing
- `node -e "global.document={querySelector:()=>null}; import('./js/tests.js').then(m=>m.runTests())"`


------
https://chatgpt.com/codex/tasks/task_e_689ced8c37cc832a828b75d235adcfa6