### PR TITLE
feat: add equipment system with randomised tool bonuses

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -28,6 +28,8 @@ export const data = {
   xp: 0,
   skills: baseSkills(),
   inventory,
+  equipment: [],
+  equipped: {},
   upgrades: {},
   craftingQueue: [],
   activeSkill: 'Woodcutting',

--- a/js/equipment.js
+++ b/js/equipment.js
@@ -1,0 +1,47 @@
+import {data, itemMap} from './data.js';
+
+let nextId = 1;
+
+function getSkill(key) {
+  const k = key.toLowerCase();
+  if (k.includes('pickaxe')) return 'Mining';
+  if (k.includes('axe')) return 'Woodcutting';
+  return null;
+}
+
+export function addEquipment(key) {
+  const skill = getSkill(key);
+  if (!skill) return false;
+  const item = {
+    id: nextId++,
+    key,
+    name: itemMap[key] || key,
+    skill,
+    speed: Math.random() * 0.2,
+    yield: Math.random() * 0.2,
+  };
+  data.equipment.push(item);
+  return true;
+}
+
+export function equipItem(id) {
+  const it = data.equipment.find(e => e.id === id);
+  if (!it) return;
+  if (data.equipped[it.skill] === id) {
+    delete data.equipped[it.skill];
+  } else {
+    data.equipped[it.skill] = id;
+  }
+}
+
+export function getBonus(skill) {
+  const id = data.equipped[skill];
+  if (!id) return {speed: 1, yield: 1};
+  const it = data.equipment.find(e => e.id === id);
+  if (!it) return {speed: 1, yield: 1};
+  return {speed: 1 + it.speed, yield: 1 + it.yield};
+}
+
+export function isEquipable(key) {
+  return !!getSkill(key);
+}

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,6 +1,7 @@
 import {data} from './data.js';
 import upgrades from './upgrades/index.js';
 import {clamp} from './utils.js';
+import {getBonus} from './equipment.js';
 
 export function addInventory(key, amount) {
   data.inventory[key] = (data.inventory[key] || 0) + amount;
@@ -52,4 +53,6 @@ export const mul = {
   skillSpeed: skill => productOf(u => u.type === skill && u.eff.speed),
   craftValue: () => productOf(u => u.type === 'craft' && u.eff.craftValue),
   offlineFrac: skill => sumOf(u => u.type === skill && u.eff.offline),
+  equipSpeed: skill => getBonus(skill).speed,
+  equipYield: skill => getBonus(skill).yield,
 };

--- a/js/loop.js
+++ b/js/loop.js
@@ -14,7 +14,7 @@ export function tick(dt) {
   stats.totalTicks++;
   const skill = data.activeSkill; const taskKey = data.skills[skill].task; const node = nodes[skill].find(n => n.key === taskKey);
   if (node) {
-    data.skills[skill]._prog = (data.skills[skill]._prog || 0) + dt * (mul.globalSpeed() * mul.skillSpeed(skill));
+    data.skills[skill]._prog = (data.skills[skill]._prog || 0) + dt * (mul.globalSpeed() * mul.skillSpeed(skill) * mul.equipSpeed(skill));
     let need = Array.isArray(node.time) ? data.skills[skill]._need || randInt(node.time[0], node.time[1]) : node.time;
     if (Array.isArray(node.time)) data.skills[skill]._need = need;
     if (data.skills[skill]._prog >= need) {

--- a/js/persistence.js
+++ b/js/persistence.js
@@ -42,6 +42,8 @@ export function load() {
       Object.assign(stats, obj.stats || {});
       convertLegacyLogs();
       data.inventory = Object.assign({}, baseInventory, data.inventory);
+      if (!Array.isArray(data.equipment)) data.equipment = [];
+      if (!data.equipped) data.equipped = {};
       applyUpgradeEffects();
       if (data.meta.virtualLevels == null) data.meta.virtualLevels = false;
     } catch (e) { console.warn('Load failed', e); }
@@ -71,6 +73,8 @@ export async function importSave() {
     Object.assign(stats, obj.stats || {});
     convertLegacyLogs();
     data.inventory = Object.assign({}, baseInventory, data.inventory);
+    if (!Array.isArray(data.equipment)) data.equipment = [];
+    if (!data.equipped) data.equipped = {};
     applyUpgradeEffects();
     save();
     renderAll();

--- a/js/progress.js
+++ b/js/progress.js
@@ -1,5 +1,6 @@
 import {data} from './data.js';
 import {mul, addInventory, applyUpgradeEffects} from './helpers.js';
+import {addEquipment} from './equipment.js';
 import {randInt, levelFromXP} from './utils.js';
 import {showToast} from './toast.js';
 
@@ -15,4 +16,4 @@ export function addSkillXP(skill, amount) {
   }
 }
 
-export const helpers = {addInventory, addSkillXP, randInt, mul};
+export const helpers = {addInventory, addEquipment, addSkillXP, randInt, mul};

--- a/js/render.js
+++ b/js/render.js
@@ -5,6 +5,7 @@ import {VERSION} from './constants.js';
 import achievements from './achievements.js';
 import enemies from './enemies.js';
 import {mul, canAfford, applyUpgradeEffects} from './helpers.js';
+import {equipItem} from './equipment.js';
 import {queueCraft} from './crafting.js';
 import {getEnemy} from './combat.js';
 import {el, fmt, xpForLevel, levelFromXP} from './utils.js';
@@ -24,7 +25,7 @@ export function activateTab(id, btn) {
 
 export function renderTabs() {
   const t = el('#tabs'); t.innerHTML = '';
-  const list = [['overview', 'Overview'], ['inventory', 'Inventory'], ['crafting', 'Crafting'], ['upgrades', 'Upgrades'], ['combat', 'Combat'], ['achievements', 'Achievements'], ['settings', 'Settings']];
+  const list = [['overview', 'Overview'], ['inventory', 'Inventory'], ['equipment', 'Equipment'], ['crafting', 'Crafting'], ['upgrades', 'Upgrades'], ['combat', 'Combat'], ['achievements', 'Achievements'], ['settings', 'Settings']];
   list.forEach(([id, label], i) => { const b = tabButton(id, label); if (i === 0) b.setAttribute('aria-selected', 'true'); t.appendChild(b); });
   activateTab('overview');
 }
@@ -110,6 +111,22 @@ export function renderInventory() {
     card.innerHTML = `<div class="phead"><b>${name}</b><small class="muted">Resource</small></div><div class="kv"><b>${fmt(v)}</b></div>`;
     g.appendChild(card);
   }
+}
+
+export function renderEquipment() {
+  const g = el('#eqGrid'); if (!g) return; g.innerHTML = '';
+  data.equipment.forEach(it => {
+    const card = document.createElement('div'); card.className = 'panel';
+    const eq = data.equipped[it.skill] === it.id;
+    card.innerHTML = `<div class="phead"><b>${it.name}</b><small class="muted">${it.skill}</small></div>
+    <div class="list">
+      <div class="item"><span>Speed</span><span>+${Math.round(it.speed * 100)}%</span></div>
+      <div class="item"><span>Yield</span><span>+${Math.round(it.yield * 100)}%</span></div>
+    </div>
+    <div class="footer"><button class="btn ${eq ? 'good' : ''}">${eq ? 'Equipped' : 'Equip'}</button></div>`;
+    card.querySelector('button').addEventListener('click', () => { equipItem(it.id); renderEquipment(); });
+    g.appendChild(card);
+  });
 }
 
 export function renderCrafting() {
@@ -209,5 +226,5 @@ export function renderSettingsFooter() {
 }
 
 export function renderAll() {
-  renderStats(); renderSkills(); renderTaskPanel(); renderOverview(); renderInventory(); renderCrafting(); renderUpgrades(); renderAchievements(); renderCombatUI();
+  renderStats(); renderSkills(); renderTaskPanel(); renderOverview(); renderInventory(); renderEquipment(); renderCrafting(); renderUpgrades(); renderAchievements(); renderCombatUI();
 }

--- a/js/skills/Mining/index.js
+++ b/js/skills/Mining/index.js
@@ -15,10 +15,11 @@ export const nodes = [
   {key: diamond.key, name: 'Diamond Deposit', time: 9000, yield: {[diamond.key]: [1, 1]}, xp: 75, req: 99},
 ];
 
-export function perform(state, node, {addInventory, addSkillXP, randInt}) {
+export function perform(state, node, {addInventory, addSkillXP, randInt, mul}) {
   if(node.consume && !Object.entries(node.consume).every(([k,v])=> (state.inventory[k]||0)>=v)) return false;
   if(node.consume) for(const [k,v] of Object.entries(node.consume)) state.inventory[k]-=v;
-  for(const [k,[a,b]] of Object.entries(node.yield||{})) addInventory(k, randInt(a,b));
+  const bonus = mul.equipYield ? mul.equipYield(skill) : 1;
+  for(const [k,[a,b]] of Object.entries(node.yield||{})) addInventory(k, Math.floor(randInt(a,b) * bonus));
   addSkillXP(skill, node.xp);
   return true;
 }

--- a/js/skills/Smithing/index.js
+++ b/js/skills/Smithing/index.js
@@ -51,10 +51,15 @@ export const nodes = [
   })),
 ];
 
-export function perform(state, node, {addInventory, addSkillXP, randInt}) {
+export function perform(state, node, {addInventory, addEquipment, addSkillXP, randInt}) {
   if (node.consume && !Object.entries(node.consume).every(([k, v]) => (state.inventory[k] || 0) >= v)) return false;
   if (node.consume) for (const [k, v] of Object.entries(node.consume)) state.inventory[k] -= v;
-  for (const [k, [a, b]] of Object.entries(node.yield || {})) addInventory(k, randInt(a, b));
+  for (const [k, [a, b]] of Object.entries(node.yield || {})) {
+    const amt = randInt(a, b);
+    for (let i = 0; i < amt; i++) {
+      if (!addEquipment(k)) addInventory(k, 1);
+    }
+  }
   addSkillXP(skill, node.xp);
   return true;
 }

--- a/js/skills/Woodcutting/index.js
+++ b/js/skills/Woodcutting/index.js
@@ -15,10 +15,11 @@ export const nodes = [
   {key: baobab.key, name: 'Baobab', time: 9000, yield: {[baobab.key]: [1, 1]}, xp: 75, req: 99},
 ];
 
-export function perform(state, node, {addInventory, addSkillXP, randInt}) {
+export function perform(state, node, {addInventory, addSkillXP, randInt, mul}) {
   if(node.consume && !Object.entries(node.consume).every(([k,v])=> (state.inventory[k]||0)>=v)) return false;
   if(node.consume) for(const [k,v] of Object.entries(node.consume)) state.inventory[k]-=v;
-  for(const [k,[a,b]] of Object.entries(node.yield||{})) addInventory(k, randInt(a,b));
+  const bonus = mul.equipYield ? mul.equipYield(skill) : 1;
+  for(const [k,[a,b]] of Object.entries(node.yield||{})) addInventory(k, Math.floor(randInt(a,b) * bonus));
   addSkillXP(skill, node.xp);
   return true;
 }

--- a/modules/main.html
+++ b/modules/main.html
@@ -17,6 +17,11 @@
       <div class="grid" id="invGrid"></div>
     </section>
 
+    <section class="panel" id="tab-equipment" role="tabpanel" hidden>
+      <div class="phead"><b>Equipment</b><small class="muted">Manage your tools</small></div>
+      <div class="grid" id="eqGrid"></div>
+    </section>
+
     <section class="panel" id="tab-crafting" role="tabpanel" hidden>
       <div class="phead"><b>Crafting</b><small class="muted">Turn resources into useful goods</small></div>
       <div class="row" style="margin-bottom:8px">


### PR DESCRIPTION
## Summary
- add data structures and logic for equippable tools with random speed and yield bonuses
- forge pickaxes and axes now create unique equipment, which can be equipped per skill and affect gathering speed/yield
- introduce Equipment tab to view and equip crafted tools

## Testing
- `node --input-type=module -e "import('./js/equipment.js').then(()=>console.log('loaded')).catch(e=>console.error(e))"`


------
https://chatgpt.com/codex/tasks/task_e_689ceebcfc10832a9f622bd2bdb2f7f5