### PR TITLE
feat: add timed global upgrade

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -18,9 +18,11 @@ export function applyUpgradeEffects() {
   const lvl = data.skills.Endurance ? data.skills.Endurance.lvl : 1;
   p.hpMax = Math.floor(p.hpMax * Math.pow(1.02, lvl - 1));
   let hpFlat = 0;
+  const now = Date.now();
   for (const k in data.upgrades) {
     const u = upgrades.find(v => v.key === k); if (!u) continue;
-    const lvl = data.upgrades[k];
+    const lvl = u.duration ? (data.upgrades[k] > now ? 1 : 0) : data.upgrades[k];
+    if (!lvl) continue;
     if (u.type === 'combatFlat') { if (u.eff.atk) p.atk += u.eff.atk * lvl; if (u.eff.def) p.def += u.eff.def * lvl; if (u.eff.hp) hpFlat += u.eff.hp * lvl; }
     if (u.type === 'combatMul') { if (u.eff.spd) p.spd *= Math.pow(u.eff.spd, lvl); }
   }
@@ -29,18 +31,22 @@ export function applyUpgradeEffects() {
 
 function productOf(pred) {
   let m = 1;
+  const now = Date.now();
   for (const k in data.upgrades) {
-    const u = upgrades.find(v => v.key === k);
-    if (u && pred(u)) m *= Math.pow(Object.values(u.eff)[0], data.upgrades[k]);
+    const u = upgrades.find(v => v.key === k); if (!u) continue;
+    const lvl = u.duration ? (data.upgrades[k] > now ? 1 : 0) : data.upgrades[k];
+    if (lvl && pred(u)) m *= Math.pow(Object.values(u.eff)[0], lvl);
   }
   return m;
 }
 
 function sumOf(pred) {
   let s = 0;
+  const now = Date.now();
   for (const k in data.upgrades) {
-    const u = upgrades.find(v => v.key === k);
-    if (u && pred(u)) { const key = Object.keys(u.eff)[0]; s += u.eff[key] * data.upgrades[k]; }
+    const u = upgrades.find(v => v.key === k); if (!u) continue;
+    const lvl = u.duration ? (data.upgrades[k] > now ? 1 : 0) : data.upgrades[k];
+    if (lvl && pred(u)) { const key = Object.keys(u.eff)[0]; s += u.eff[key] * lvl; }
   }
   return s;
 }

--- a/js/render.js
+++ b/js/render.js
@@ -216,16 +216,25 @@ export function renderUpgrades() {
   const filter = sel ? sel.value : 'all';
   const g = el('#upgGrid'); g.innerHTML = '';
   upgrades.filter(u => filter === 'all' || u.type === filter).forEach(u => {
-    const lvl = data.upgrades[u.key] || 0; const maxed = lvl >= u.max;
-    const cost = Math.floor(u.cost * Math.pow(1.75, lvl));
+    const now = Date.now();
+    const exp = data.upgrades[u.key] || 0;
+    const active = u.duration && exp > now;
+    const lvl = u.duration ? (active ? 1 : 0) : (data.upgrades[u.key] || 0);
+    const maxed = u.duration ? active : lvl >= u.max;
+    const cost = u.duration ? u.cost : Math.floor(u.cost * Math.pow(1.75, lvl));
     const can = canAfford(cost) && !maxed;
+    const status = u.duration ? (active ? 'Active' : 'Inactive') : `Lv ${lvl}/${u.max}`;
     const card = document.createElement('div'); card.className = 'panel';
     card.innerHTML = `<div class="phead"><b>${u.name}</b><small class="muted">${u.type}</small></div>
     <p class="hint">${u.desc}</p>
-    <div class="row"><span class="chip">Lv ${lvl}/${u.max}</span><span class="chip">Cost ${fmt(cost)}</span></div>
+    <div class="row"><span class="chip">${status}</span><span class="chip">Cost ${fmt(cost)}</span></div>
     <div class="footer"><button class="btn ${can ? 'good' : ''}" ${!can ? 'disabled' : ''}>Buy</button></div>`;
     card.querySelector('button').addEventListener('click', () => {
-      if (data.gold < cost || maxed) return; data.gold -= cost; data.upgrades[u.key] = (data.upgrades[u.key] || 0) + 1; applyUpgradeEffects(); renderAll();
+      if (data.gold < cost || maxed) return;
+      data.gold -= cost;
+      if (u.duration) data.upgrades[u.key] = Date.now() + u.duration;
+      else data.upgrades[u.key] = (data.upgrades[u.key] || 0) + 1;
+      applyUpgradeEffects(); renderAll();
     });
     g.appendChild(card);
   });

--- a/js/upgrades/global.js
+++ b/js/upgrades/global.js
@@ -1,5 +1,3 @@
 export default [
-  {key:'pack1', name:'Bigger Pockets', desc:'+25% inventory gains', cost:50, max:1, type:'global', eff:{gain:1.25}},
-  {key:'focus1', name:'Focused Mind', desc:'+20% XP across all skills', cost:120, max:1, type:'global', eff:{xp:1.2}},
-  {key:'hustle', name:'Hustle', desc:'+10% global speed', cost:150, max:3, type:'global', eff:{speed:1.1}},
+  {key:'pack1', name:'Bigger Pockets', desc:'+25% inventory gains for 5 minutes', cost:100, duration:300000, type:'global', eff:{gain:1.25}},
 ];

--- a/modules/main.html
+++ b/modules/main.html
@@ -23,7 +23,7 @@
     </section>
   
     <section class="panel" id="tab-upgrades" role="tabpanel" hidden>
-      <div class="phead"><b>Upgrades</b><small class="muted">Permanent boosts</small></div>
+      <div class="phead"><b>Upgrades</b><small class="muted">Temporary boosts</small></div>
       <div class="row">
         <span class="muted">Filter</span>
         <select id="upgFilter">


### PR DESCRIPTION
## Summary
- replace permanent global upgrades with a timed Bigger Pockets boost
- handle expiring upgrades in effect helpers and UI
- retitle upgrades panel to emphasize temporary buffs

## Testing
- `node --check js/upgrades/global.js js/helpers.js js/render.js`
- `node --input-type=module -e "import('./js/tests.js').then(m=>m.runTests())"` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689cf37d7000832a918cee67a0cd8852