### PR TITLE
Render farm timers every second

### DIFF
--- a/js/loop.js
+++ b/js/loop.js
@@ -60,6 +60,8 @@ export function tick(dt) {
     renderOverview();
     renderInventory();
     renderSkills();
+  }
+  if (stats.totalTicks % Math.floor(1000 / TICK_MS) === 0) {
     renderFarm();
   }
 }


### PR DESCRIPTION
## Summary
- Ensure farm plot timers refresh every second to avoid skipped countdown values

## Testing
- `node --check js/loop.js`
- Attempted to import game modules; failed with `ReferenceError: document is not defined` (headless environment)


------
https://chatgpt.com/codex/tasks/task_e_689cf3cc4180832a8a67f8fa1780b1c3