### PR TITLE
Add Alchemy skill with items and upgrades

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -4,12 +4,13 @@ import Mining from './skills/Mining/index.js';
 import Fishing from './skills/Fishing/index.js';
 import Smithing from './skills/Smithing/index.js';
 import Cooking from './skills/Cooking/index.js';
+import Alchemy from './skills/Alchemy/index.js';
 import Combat from './skills/Combat/index.js';
 import Endurance from './skills/Endurance/index.js';
 import Farming from './skills/Farming/index.js';
 import {VERSION} from './constants.js';
 
-export const skillModules = { Woodcutting, Mining, Fishing, Smithing, Cooking, Combat, Endurance, Farming };
+export const skillModules = { Woodcutting, Mining, Fishing, Smithing, Cooking, Alchemy, Combat, Endurance, Farming };
 export const skills = Object.keys(skillModules);
 export const nodes = Object.fromEntries(skills.map(k => [k, skillModules[k].nodes]));
 export const inventory = Object.fromEntries(items.map(i => [i.key, 0]));

--- a/js/items.js
+++ b/js/items.js
@@ -68,5 +68,9 @@ export default [
   {key:'bread', name:'Bread'},
   {key:'stew', name:'Stew'},
   {key:'pie', name:'Pie'},
-  {key:'fishStew', name:'Fish Stew'}
+  {key:'fishStew', name:'Fish Stew'},
+  {key:'redHerb', name:'Red Herb'},
+  {key:'blueHerb', name:'Blue Herb'},
+  {key:'healingPotion', name:'Healing Potion'},
+  {key:'manaPotion', name:'Mana Potion'}
 ];

--- a/js/render/skills.js
+++ b/js/render/skills.js
@@ -18,7 +18,8 @@ export function renderSkills() {
     const pct = sk.lvl >= 99 && !data.meta.virtualLevels ? 100 : ((sk.xp - cur) / (next - cur)) * 100;
     const lvlText = data.meta.virtualLevels ? actual : sk.lvl;
     const isFarm = name === 'Farming';
-    const btnText = isFarm ? 'Manage' : active ? 'Training' : 'Train';
+    const isAlchemy = name === 'Alchemy';
+    const btnText = isFarm ? 'Manage' : active ? (isAlchemy ? 'Brewing' : 'Training') : (isAlchemy ? 'Brew' : 'Train');
     row.innerHTML = `<div><b>${name}</b><div class="bar"><span style="width:${pct}%"></span></div><small class="muted">Lv ${lvlText} · ${fmt(sk.xp)} XP</small></div><div class="row"><button class="btn ${active && !isFarm ? 'good' : ''}">${btnText}</button></div>`;
     const btn = row.querySelector('button');
     if (isFarm) {

--- a/js/skills/Alchemy/index.js
+++ b/js/skills/Alchemy/index.js
@@ -1,0 +1,50 @@
+import items from '../../items.js';
+
+const skill = 'Alchemy';
+const map = Object.fromEntries(items.map(i => [i.key, i]));
+const {
+  redHerb,
+  blueHerb,
+  healingPotion,
+  manaPotion,
+} = map;
+
+export const nodes = [
+  {
+    key: healingPotion.key,
+    name: 'Brew Healing Potion',
+    time: 5000,
+    consume: {[redHerb.key]: 2},
+    yield: {[healingPotion.key]: [1, 1]},
+    xp: 12,
+    req: 3,
+  },
+  {
+    key: manaPotion.key,
+    name: 'Brew Mana Potion',
+    time: 5500,
+    consume: {[blueHerb.key]: 2},
+    yield: {[manaPotion.key]: [1, 1]},
+    xp: 15,
+    req: 5,
+  },
+];
+
+export function perform(state, node, {addInventory, addSkillXP, randInt, mul}) {
+  if (node.consume && !Object.entries(node.consume).every(([k, v]) => (state.inventory[k] || 0) >= v)) return false;
+  if (node.consume) for (const [k, v] of Object.entries(node.consume)) state.inventory[k] -= v;
+  for (const [k, [a, b]] of Object.entries(node.yield || {})) {
+    if (k === 'gold') {
+      const base = randInt(a, b);
+      state.gold += base;
+      const extra = mul.craftValue() - 1;
+      if (extra > 0) state.gold += Math.floor(base * extra);
+    } else {
+      addInventory(k, randInt(a, b));
+    }
+  }
+  addSkillXP(skill, node.xp);
+  return true;
+}
+
+export default {nodes, perform};

--- a/js/upgrades/Alchemy.js
+++ b/js/upgrades/Alchemy.js
@@ -1,0 +1,3 @@
+export default [
+  {key:'mortar', name:'Mortar & Pestle', desc:'Alchemy speed +20%', cost:150, max:1, type:'Alchemy', eff:{speed:1.2}},
+];

--- a/js/upgrades/index.js
+++ b/js/upgrades/index.js
@@ -4,6 +4,7 @@ import mining from './Mining.js';
 import fishing from './Fishing.js';
 import smithing from './Smithing.js';
 import cooking from './Cooking.js';
+import alchemy from './Alchemy.js';
 import craft from './Craft.js';
 import combat from './Combat.js';
 
@@ -14,6 +15,7 @@ export default [
   ...fishing,
   ...smithing,
   ...cooking,
+  ...alchemy,
   ...craft,
   ...combat,
 ];


### PR DESCRIPTION
## Summary
- Introduce Alchemy skill with potion recipes and crafting logic
- Register Alchemy across data structures and render it with dedicated brewing UI text
- Add herbs, potions, and related Alchemy upgrade

## Testing
- `node --check js/skills/Alchemy/index.js`
- `node --check js/data.js`
- `node --check js/render/skills.js`
- `node --check js/items.js`
- `node --check js/upgrades/Alchemy.js`
- `node --check js/upgrades/index.js`


------
https://chatgpt.com/codex/tasks/task_e_689d2a23049c832aabe06326ea15a94c