### PR TITLE
Add user-priced selling queue to market

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -15,7 +15,7 @@ export const skills = Object.keys(skillModules);
 export const nodes = Object.fromEntries(skills.map(k => [k, skillModules[k].nodes]));
 export const inventory = Object.fromEntries(items.map(i => [i.key, 0]));
 export const itemMap = Object.fromEntries(items.map(i => [i.key, i.name]));
-export const marketInventory = Object.fromEntries(items.map(i => [i.key, {price: 10, stock: 10}]));
+export const marketInventory = Object.fromEntries(items.map(i => [i.key, {base: 10}]));
 
 function baseSkills() {
   const obj = {};
@@ -39,6 +39,7 @@ export const data = {
   craftingQueue: [],
   activeSkill: 'Woodcutting',
   market: JSON.parse(JSON.stringify(marketInventory)),
+  marketQueue: [],
   combat: { running: false, area: 'Glade', player: { hpMax: 10, hp: 10, atk: 4, def: 2, spd: 1.0, crit: 0.05 }, enemyKey: 'Slime', progress: 0 },
   ach: {},
 };

--- a/js/loop.js
+++ b/js/loop.js
@@ -9,7 +9,7 @@ import {checkAchievements} from './achievementCheck.js';
 import {save} from './persistence.js';
 import {renderStats, renderOverview, renderInventory, renderSkills, renderFarm, renderMarket} from './render.js';
 import {el, randInt} from './utils.js';
-import {updateMarketPrices} from './market.js';
+import {processMarket} from './market.js';
 
 export function tick(dt) {
   stats.totalTicks++;
@@ -66,7 +66,7 @@ export function tick(dt) {
     renderFarm();
   }
   if (stats.totalTicks % Math.floor(10000 / TICK_MS) === 0) {
-    updateMarketPrices();
+    processMarket();
     renderMarket();
   }
 }

--- a/js/market.js
+++ b/js/market.js
@@ -1,26 +1,23 @@
 import {data} from './data.js';
 
-export function buyItem(key) {
-  const entry = data.market[key];
-  if (!entry || entry.stock <= 0) return;
-  if (data.gold < entry.price) return;
-  data.gold -= entry.price;
-  data.inventory[key] = (data.inventory[key] || 0) + 1;
-  entry.stock--;
-}
-
-export function sellItem(key) {
+export function listItem(key, price) {
   if ((data.inventory[key] || 0) <= 0) return;
   const entry = data.market[key];
   if (!entry) return;
-  data.gold += entry.price;
+  const base = entry.base || 1;
+  price = Math.max(1, Math.floor(price));
+  if (price > base * 100) return;
   data.inventory[key]--;
-  entry.stock++;
+  data.marketQueue.push({key, price, base});
 }
 
-export function updateMarketPrices() {
-  Object.values(data.market).forEach(it => {
-    const delta = Math.random() < 0.5 ? -1 : 1;
-    it.price = Math.max(1, it.price + delta);
-  });
+export function processMarket() {
+  if (!data.marketQueue.length) return;
+  const listing = data.marketQueue[0];
+  const chance = Math.min(1, listing.base / listing.price);
+  if (Math.random() < chance) {
+    data.gold += listing.price;
+    data.marketQueue.shift();
+  }
 }
+

--- a/js/persistence.js
+++ b/js/persistence.js
@@ -43,6 +43,7 @@ export function load() {
       convertLegacyLogs();
       data.inventory = Object.assign({}, baseInventory, data.inventory);
       data.market = Object.assign(JSON.parse(JSON.stringify(baseMarket)), data.market);
+      if (!Array.isArray(data.marketQueue)) data.marketQueue = [];
       if (!Array.isArray(data.equipment)) data.equipment = [];
       if (!data.equipped) data.equipped = {};
       data.equipment.forEach(it => {
@@ -84,6 +85,7 @@ export async function importSave() {
     convertLegacyLogs();
     data.inventory = Object.assign({}, baseInventory, data.inventory);
     data.market = Object.assign(JSON.parse(JSON.stringify(baseMarket)), data.market);
+    if (!Array.isArray(data.marketQueue)) data.marketQueue = [];
     if (!Array.isArray(data.equipment)) data.equipment = [];
     if (!data.equipped) data.equipped = {};
     data.equipment.forEach(it => {

--- a/js/render/market.js
+++ b/js/render/market.js
@@ -1,23 +1,32 @@
 import {data, itemMap} from '../data.js';
 import {el, fmt} from '../utils.js';
-import {buyItem, sellItem} from '../market.js';
+import {listItem} from '../market.js';
 
 export function renderMarket() {
   const g = el('#marketGrid');
   if (!g) return;
   g.innerHTML = '';
+  const queued = {};
+  data.marketQueue.forEach(it => { queued[it.key] = (queued[it.key] || 0) + 1; });
   for (const [k, v] of Object.entries(data.market)) {
     const owned = data.inventory[k] || 0;
-    if (v.stock <= 0 && owned <= 0) continue;
+    const q = queued[k] || 0;
+    if (owned <= 0 && q <= 0) continue;
     const card = document.createElement('div');
     card.className = 'panel';
     const name = itemMap[k] || k;
-    card.innerHTML = `<div class="phead"><b>${name}</b><small class="muted">${fmt(v.price)}g</small></div>` +
-      `<div class="row"><span>Stock: ${fmt(v.stock)}</span>` +
-      `<button class="btn" data-buy="${k}">Buy</button>` +
-      `<button class="btn" data-sell="${k}">Sell</button></div>`;
+    card.innerHTML = `<div class="phead"><b>${name}</b><small class="muted">Base ${fmt(v.base)}g</small></div>` +
+      `<div class="row"><span>Owned: ${fmt(owned)}</span>` +
+      `<input type="number" value="${v.base}" min="1" style="width:60px" data-price="${k}">` +
+      `<button class="btn" data-list="${k}">List</button></div>` +
+      (q ? `<div class="row"><span>Queued: ${fmt(q)}</span></div>` : '');
     g.appendChild(card);
   }
-  g.querySelectorAll('[data-buy]').forEach(b => b.addEventListener('click', () => { buyItem(b.dataset.buy); renderMarket(); }));
-  g.querySelectorAll('[data-sell]').forEach(b => b.addEventListener('click', () => { sellItem(b.dataset.sell); renderMarket(); }));
+  g.querySelectorAll('[data-list]').forEach(b => b.addEventListener('click', () => {
+    const key = b.dataset.list;
+    const input = g.querySelector(`[data-price="${key}"]`);
+    const price = Number(input.value);
+    listItem(key, price);
+    renderMarket();
+  }));
 }


### PR DESCRIPTION
## Summary
- Remove buying and market stock mechanics
- Allow players to set sell prices and queue items for sale with chance-based processing
- Persist and display queued sales in the market UI

## Testing
- `node --input-type=module - <<'NODE'
import {data} from './js/data.js';
import {listItem, processMarket} from './js/market.js';
data.inventory.twig = 1;
listItem('twig', 10);
console.log('queued', data.marketQueue.length);
for (let i=0; i<100; i++) processMarket();
console.log('queue left', data.marketQueue.length, 'gold', data.gold);
NODE`
- `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_689d2e9384f4832aa5242dc72f5f6036