### PR TITLE
feat: expand achievements and rewards

### DIFF
--- a/js/achievementCheck.js
+++ b/js/achievementCheck.js
@@ -5,7 +5,27 @@ import {showToast} from './toast.js';
 export function checkAchievements() {
   achievements.forEach(a => {
     if (!data.ach[a.key] && a.cond(data)) {
-      data.ach[a.key] = true; data.gold += a.reward; showToast(`Achievement: ${a.name} (+${a.reward}g)`);
+      data.ach[a.key] = true;
+      const rewardMsg = applyReward(a.reward);
+      showToast(`Achievement: ${a.name}${rewardMsg ? ' (' + rewardMsg + ')' : ''}`);
     }
   });
+}
+
+function applyReward(reward) {
+  const parts = [];
+  if (typeof reward === 'number') {
+    data.gold += reward;
+    parts.push(`+${reward}g`);
+  } else if (reward && typeof reward === 'object') {
+    if (reward.gold) {
+      data.gold += reward.gold;
+      parts.push(`+${reward.gold}g`);
+    }
+    if (reward.xp) {
+      data.xp += reward.xp;
+      parts.push(`+${reward.xp}xp`);
+    }
+  }
+  return parts.join(', ');
 }

--- a/js/achievements.js
+++ b/js/achievements.js
@@ -5,4 +5,8 @@ export default [
   {key:'miner5', name:'Miner Lv.5', cond:s=>s.skills.Mining.lvl>=5, reward:30},
   {key:'cook10', name:'Chef Lv.10', cond:s=>s.skills.Cooking.lvl>=10, reward:100},
   {key:'slime50', name:'Slime Smasher', cond:s=>getStat('slimeKills')>=50, reward:80},
+  {key:'wood5', name:'Lumberjack Lv.5', cond:s=>s.skills.Woodcutting.lvl>=5, reward:40},
+  {key:'fish5', name:'Angler Lv.5', cond:s=>s.skills.Fishing.lvl>=5, reward:40},
+  {key:'combat5', name:'Warrior Lv.5', cond:s=>s.skills.Combat.lvl>=5, reward:{gold:60, xp:50}},
+  {key:'slime200', name:'Slime Annihilator', cond:s=>getStat('slimeKills')>=200, reward:{gold:150, xp:150}},
 ];


### PR DESCRIPTION
## Summary
- add woodcutting, fishing, combat, and high slime kill achievements
- allow achievements to grant gold and xp via flexible reward handler

## Testing
- `node -e "globalThis.document={querySelector:()=>null};import('./js/toast.js').then(t=>{t.setToastSuppressed(true);import('./js/tests.js').then(m=>m.runTests());});"`
- `node -e "globalThis.document={querySelector:()=>null};import('./js/toast.js').then(t=>{t.setToastSuppressed(true);import('./js/achievementCheck.js').then(m=>import('./js/data.js').then(d=>import('./js/stats.js').then(s=>{d.data.ach={};d.data.gold=0;d.data.xp=0;d.data.skills.Woodcutting.lvl=5;d.data.skills.Fishing.lvl=5;d.data.skills.Combat.lvl=5;s.stats.slimeKills=200;m.checkAchievements();console.log('ach',d.data.ach);console.log('gold',d.data.gold);console.log('xp',d.data.xp);})));})"`


------
https://chatgpt.com/codex/tasks/task_e_689d2f58a438832a8b9ced67ded03464