### PR TITLE
Add Magic skill with spellcasting nodes and UI support

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -8,9 +8,10 @@ import Alchemy from './skills/Alchemy/index.js';
 import Combat from './skills/Combat/index.js';
 import Endurance from './skills/Endurance/index.js';
 import Farming from './skills/Farming/index.js';
+import Magic from './skills/Magic/index.js';
 import {VERSION} from './constants.js';
 
-export const skillModules = { Woodcutting, Mining, Fishing, Smithing, Cooking, Alchemy, Combat, Endurance, Farming };
+export const skillModules = { Woodcutting, Mining, Fishing, Smithing, Cooking, Alchemy, Combat, Endurance, Farming, Magic };
 export const skills = Object.keys(skillModules);
 export const nodes = Object.fromEntries(skills.map(k => [k, skillModules[k].nodes]));
 export const inventory = Object.fromEntries(items.map(i => [i.key, 0]));

--- a/js/items.js
+++ b/js/items.js
@@ -72,5 +72,10 @@ export default [
   {key:'redHerb', name:'Red Herb'},
   {key:'blueHerb', name:'Blue Herb'},
   {key:'healingPotion', name:'Healing Potion'},
-  {key:'manaPotion', name:'Mana Potion'}
+  {key:'manaPotion', name:'Mana Potion'},
+  {key:'magicEssence', name:'Magic Essence'},
+  {key:'airRune', name:'Air Rune'},
+  {key:'fireRune', name:'Fire Rune'},
+  {key:'waterRune', name:'Water Rune'},
+  {key:'earthRune', name:'Earth Rune'}
 ];

--- a/js/render/skills.js
+++ b/js/render/skills.js
@@ -19,7 +19,8 @@ export function renderSkills() {
     const lvlText = data.meta.virtualLevels ? actual : sk.lvl;
     const isFarm = name === 'Farming';
     const isAlchemy = name === 'Alchemy';
-    const btnText = isFarm ? 'Manage' : active ? (isAlchemy ? 'Brewing' : 'Training') : (isAlchemy ? 'Brew' : 'Train');
+    const isMagic = name === 'Magic';
+    const btnText = isFarm ? 'Manage' : active ? (isAlchemy ? 'Brewing' : isMagic ? 'Casting' : 'Training') : (isAlchemy ? 'Brew' : isMagic ? 'Cast' : 'Train');
     row.innerHTML = `<div><b>${name}</b><div class="bar"><span style="width:${pct}%"></span></div><small class="muted">Lv ${lvlText} · ${fmt(sk.xp)} XP</small></div><div class="row"><button class="btn ${active && !isFarm ? 'good' : ''}">${btnText}</button></div>`;
     const btn = row.querySelector('button');
     if (isFarm) {
@@ -85,7 +86,8 @@ export function renderTaskPanel() {
         </div>`;
       const b = document.createElement('button');
       b.className = 'btn';
-      b.textContent = sk.task === node.key ? 'Stop' : 'Train';
+      const actionLabel = skillName === 'Alchemy' ? 'Brew' : skillName === 'Magic' ? 'Cast' : 'Train';
+      b.textContent = sk.task === node.key ? 'Stop' : actionLabel;
       if (locked) b.disabled = true;
       if (sk.task === node.key) b.classList.add('good');
       b.addEventListener('click', () => {
@@ -122,7 +124,8 @@ export function renderTaskPanel() {
           </div>`;
       const b = document.createElement('button');
       b.className = 'btn';
-      b.textContent = sk.task === node.key ? 'Stop' : 'Train';
+      const actionLabel = skillName === 'Alchemy' ? 'Brew' : skillName === 'Magic' ? 'Cast' : 'Train';
+      b.textContent = sk.task === node.key ? 'Stop' : actionLabel;
       if (locked) b.disabled = true;
       if (sk.task === node.key) b.classList.add('good');
       b.addEventListener('click', () => {

--- a/js/skills/Magic/index.js
+++ b/js/skills/Magic/index.js
@@ -1,0 +1,23 @@
+import items from '../../items.js';
+
+const skill = 'Magic';
+const map = Object.fromEntries(items.map(i => [i.key, i]));
+const { airRune, fireRune, waterRune, earthRune, magicEssence } = map;
+
+export const nodes = [
+  { key: 'gust', name: 'Cast Gust', time: 3000, consume: { [airRune.key]: 1 }, yield: { [magicEssence.key]: [1, 1] }, xp: 8, req: 1 },
+  { key: 'fireball', name: 'Cast Fireball', time: 4000, consume: { [fireRune.key]: 1 }, yield: { [magicEssence.key]: [1, 2] }, xp: 15, req: 15 },
+  { key: 'waterSurge', name: 'Cast Water Surge', time: 5000, consume: { [waterRune.key]: 1 }, yield: { [magicEssence.key]: [2, 3] }, xp: 25, req: 30 },
+  { key: 'earthShield', name: 'Cast Earth Shield', time: 6000, consume: { [earthRune.key]: 1 }, yield: { [magicEssence.key]: [3, 4] }, xp: 40, req: 45 },
+];
+
+export function perform(state, node, {addInventory, addSkillXP, randInt, mul}) {
+  if (node.consume && !Object.entries(node.consume).every(([k, v]) => (state.inventory[k] || 0) >= v)) return false;
+  if (node.consume) for (const [k, v] of Object.entries(node.consume)) state.inventory[k] -= v;
+  const bonus = mul.equipYield ? mul.equipYield(skill) : 1;
+  for (const [k, [a, b]] of Object.entries(node.yield || {})) addInventory(k, Math.floor(randInt(a, b) * bonus));
+  addSkillXP(skill, node.xp);
+  return true;
+}
+
+export default {nodes, perform};


### PR DESCRIPTION
## Summary
- introduce Magic skill with rune-based spell nodes
- wire Magic into game data and inventory
- extend renderer to show Cast/Casting actions

## Testing
- `node -e "global.document={querySelector:()=>null};import('./js/tests.js').then(m=>m.runTests())"`

------
https://chatgpt.com/codex/tasks/task_e_689d2f59de60832aa4478622be2c5309