### PR TITLE
Fix syntax error in settings footer renderer

### DIFF
--- a/js/render/settings.js
+++ b/js/render/settings.js
@@ -16,6 +16,7 @@ export function renderSettingsFooter() {
     sel.value = getLang();
     sel.addEventListener('change', e => setLang(e.target.value));
     sel.dataset.init = '1';
+  }
   const cont = el('#optOfflineSkills');
   if (cont) {
     cont.innerHTML = '';


### PR DESCRIPTION
## Summary
- Close missing brace in settings footer language initialization

## Testing
- `node --check js/render/settings.js`
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689d3230bde4832a8da855b767a087f9