### PR TITLE
Fix reward text rendering for achievements

### DIFF
--- a/js/render/achievements.js
+++ b/js/render/achievements.js
@@ -7,9 +7,21 @@ export function renderAchievements() {
   achievements.forEach(a => {
     const owned = !!data.ach[a.key];
     const card = document.createElement('div'); card.className = 'panel';
-    card.innerHTML = `<div class="phead"><b>${a.name}</b><small class="muted">Reward ${a.reward}g</small></div>
-    <div class="row"><span class="chip">${owned ? 'Claimed' : 'Locked/Auto'}</span></div>`;
+    const reward = formatReward(a.reward);
+    card.innerHTML = `<div class="phead"><b>${a.name}</b><small class="muted">Reward ${reward}</small></div>` +
+      `<div class="row"><span class="chip">${owned ? 'Claimed' : 'Locked/Auto'}</span></div>`;
     g.appendChild(card);
   });
+}
+
+function formatReward(reward) {
+  if (typeof reward === 'number') return `${reward}g`;
+  if (reward && typeof reward === 'object') {
+    const parts = [];
+    if (reward.gold) parts.push(`${reward.gold}g`);
+    if (reward.xp) parts.push(`${reward.xp}xp`);
+    return parts.join(', ');
+  }
+  return '';
 }
 


### PR DESCRIPTION
## Summary
- ensure achievement rewards with multiple types display correctly

## Testing
- `node --check js/render/achievements.js`
- `node --input-type=module -e "const grid={innerHTML:'',children:[],appendChild(el){this.children.push(el);}};global.document={querySelector:(sel)=>sel=='#achGrid'?grid:null,createElement:(tag)=>({tag,className:'',innerHTML:'',appendChild(){},})};import('./js/render/achievements.js').then(m=>{m.renderAchievements(); console.log(grid.children.map(c=>c.innerHTML));});"`

------
https://chatgpt.com/codex/tasks/task_e_689d33796c34832ab199e8eccd1250fc